### PR TITLE
updated saxon to 8.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
       <dependency>
 		<groupId>net.sf.saxon</groupId>
 		<artifactId>saxon</artifactId>
-		<version>7.3.1</version>
+		<version>8.7</version>
 	</dependency>
      <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
The public maven repo doesn't have saxon 7.3.1 available, upgraded to the latest version of 8.7 instead.

http://mvnrepository.com/artifact/net.sf.saxon/saxon
