### PR TITLE
Future

### DIFF
--- a/samples/nvp/compileSample.bat
+++ b/samples/nvp/compileSample.bat
@@ -2,9 +2,9 @@
 
 set LOCAL_CP=
 rem ----------------------------------------------------------------------------
-rem Replace this with cybersource-sdk-java-6.1.1.jar when using Java SDK 1.6 or later.
+rem Replace this with cybersource-sdk-java-6.1.0.jar when using Java SDK 1.6 or later.
 rem ----------------------------------------------------------------------------
-set LOCAL_CP=%LOCAL_CP%;../../lib/cybersource-sdk-java-6.1.1.jar
+set LOCAL_CP=%LOCAL_CP%;../../lib/cybersource-sdk-java-6.1.0.jar
 
 if not exist classes mkdir classes
 

--- a/samples/nvp/compileSample.sh
+++ b/samples/nvp/compileSample.sh
@@ -2,9 +2,9 @@
 
 LOCAL_CP=
 # -----------------------------------------------------------------------------
-# Replace this with cybersource-sdk-java-6.1.1.jar when using Java SDK 1.6 or later.
+# Replace this with cybersource-sdk-java-6.1.0.jar when using Java SDK 1.6 or later.
 # -----------------------------------------------------------------------------
-LOCAL_CP=$LOCAL_CP:../../lib/cybersource-sdk-java-6.1.1.jar
+LOCAL_CP=$LOCAL_CP:../../lib/cybersource-sdk-java-6.1.0.jar
 
 if test ! -d ./classes 
 then

--- a/samples/nvp/pom.xml
+++ b/samples/nvp/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
             <groupId>com.cybersource</groupId>
             <artifactId>cybersource-sdk-java</artifactId>
-            <version>6.1.1</version>
+            <version>6.1.0</version>
     </dependency> 
     <dependency>
             <groupId>commons-httpclient</groupId>

--- a/samples/nvp/runSample.bat
+++ b/samples/nvp/runSample.bat
@@ -4,7 +4,7 @@ set LOCAL_CP=
 set LOCAL_CP=%LOCAL_CP%;classes
 
 rem ----------------------------------------------------------------------------
-rem Replace cybersource-sdk-java-6.1.1.jar with cybsclients15.jar in /lib directory when using Java SDK 1.6 or
+rem Replace cybersource-sdk-java-6.1.0.jar with cybsclients15.jar in /lib directory when using Java SDK 1.6 or
 rem later.
 rem ----------------------------------------------------------------------------
 set LOCAL_CP=%LOCAL_CP%;../../lib/*

--- a/samples/nvp/runSample.sh
+++ b/samples/nvp/runSample.sh
@@ -4,7 +4,7 @@ LOCAL_CP=
 LOCAL_CP=$LOCAL_CP:./classes
 
 # -----------------------------------------------------------------------------
-# Replace cybersource-sdk-java-6.1.1.jar with cybsclients15.jar in /lib directory when using Java SDK 1.6 or
+# Replace cybersource-sdk-java-6.1.0.jar with cybsclients15.jar in /lib directory when using Java SDK 1.6 or
 # later.
 # -----------------------------------------------------------------------------
 LOCAL_CP=$LOCAL_CP:../../lib/*

--- a/samples/xml/compileSample.bat
+++ b/samples/xml/compileSample.bat
@@ -2,9 +2,9 @@
 
 set LOCAL_CP=
 rem ----------------------------------------------------------------------------
-rem Replace this with cybersource-sdk-java-6.1.1.jar when using Java SDK 1.6 or later.
+rem Replace this with cybersource-sdk-java-6.1.0.jar when using Java SDK 1.6 or later.
 rem ----------------------------------------------------------------------------
-set LOCAL_CP=%LOCAL_CP%;../../lib/cybersource-sdk-java-6.1.1.jar
+set LOCAL_CP=%LOCAL_CP%;../../lib/cybersource-sdk-java-6.1.0.jar
 
 if not exist classes mkdir classes
 

--- a/samples/xml/compileSample.sh
+++ b/samples/xml/compileSample.sh
@@ -2,9 +2,9 @@
 
 LOCAL_CP=
 # -----------------------------------------------------------------------------
-# Replace this with cybersource-sdk-java-6.1.1.jar when using Java SDK 1.6 or later.
+# Replace this with cybersource-sdk-java-6.1.0.jar when using Java SDK 1.6 or later.
 # -----------------------------------------------------------------------------
-LOCAL_CP=$LOCAL_CP:../../lib/cybersource-sdk-java-6.1.1.jar
+LOCAL_CP=$LOCAL_CP:../../lib/cybersource-sdk-java-6.1.0.jar
 
 if test ! -d ./classes 
 then

--- a/samples/xml/pom.xml
+++ b/samples/xml/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
             <groupId>com.cybersource</groupId>
             <artifactId>cybersource-sdk-java</artifactId>
-            <version>6.1.1</version>
+            <version>6.1.0</version>
     </dependency> 
     <dependency>
             <groupId>commons-httpclient</groupId>

--- a/samples/xml/runSample.bat
+++ b/samples/xml/runSample.bat
@@ -4,7 +4,7 @@ set LOCAL_CP=
 set LOCAL_CP=%LOCAL_CP%;classes
 
 rem ----------------------------------------------------------------------------
-rem Replace cybersource-sdk-java-6.1.1.jar with cybsclients15.jar in /lib directory when using Java SDK 1.6 or
+rem Replace cybersource-sdk-java-6.1.0.jar with cybsclients15.jar in /lib directory when using Java SDK 1.6 or
 rem later.
 rem ----------------------------------------------------------------------------
 set LOCAL_CP=%LOCAL_CP%;../../lib/*

--- a/samples/xml/runSample.sh
+++ b/samples/xml/runSample.sh
@@ -4,7 +4,7 @@ LOCAL_CP=
 LOCAL_CP=$LOCAL_CP:./classes
 
 # -----------------------------------------------------------------------------
-# Replace cybersource-sdk-java-6.1.1.jar with cybsclients15.jar in /lib directory when using Java SDK 1.6 or
+# Replace cybersource-sdk-java-6.1.0.jar with cybsclients15.jar in /lib directory when using Java SDK 1.6 or
 # later.
 # -----------------------------------------------------------------------------
 LOCAL_CP=$LOCAL_CP:../../lib/*

--- a/zip/pom.xml
+++ b/zip/pom.xml
@@ -20,7 +20,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.3</version>
                 <configuration>
-                    <finalName>cybersource-sdk-java-6.1.0</finalName>
+                    <finalName>cybersource-sdk-master</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
                         <descriptor>src/main/assembly/zip.xml</descriptor>

--- a/zip/pom.xml
+++ b/zip/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>cybersource-sdk-master</artifactId>
         <groupId>com.cybersource</groupId>
-        <version>6.1.1</version>
+        <version>6.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -20,7 +20,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.3</version>
                 <configuration>
-                    <finalName>cybersource-sdk-master</finalName>
+                    <finalName>cybersource-sdk-java-6.1.0</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
                         <descriptor>src/main/assembly/zip.xml</descriptor>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.cybersource</groupId>
             <artifactId>cybersource-sdk-java</artifactId>
-            <version>6.1.1</version>
+            <version>6.1.0</version>
         </dependency>
     </dependencies>
 

--- a/zip/src/main/assembly/zip.xml
+++ b/zip/src/main/assembly/zip.xml
@@ -8,7 +8,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>cybersource-sdk-java-master/lib</outputDirectory>
+            <outputDirectory>cybersource-sdk-java/lib</outputDirectory>
             <includes>
                 <include>com.cybersource:cybersource-sdk-java</include>
                 <include>*:jar:*</include>
@@ -18,21 +18,21 @@
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}/../..</directory>
-            <outputDirectory>cybersource-sdk-java-master</outputDirectory>
+            <outputDirectory>cybersource-sdk-java</outputDirectory>
             <includes>
                 <include>License.txt</include>
             </includes>
         </fileSet>
 		<fileSet>
             <directory>${project.build.directory}/..</directory>
-            <outputDirectory>cybersource-sdk-java-master</outputDirectory>
+            <outputDirectory>cybersource-sdk-java</outputDirectory>
             <includes>
                 <include>README</include>
             </includes>
         </fileSet>
 		<fileSet>
             <directory>${project.build.directory}/../../samples</directory>
-            <outputDirectory>cybersource-sdk-java-master/samples</outputDirectory>
+            <outputDirectory>cybersource-sdk-java/samples</outputDirectory>
             <includes>
                 <include>**/*</include>
             </includes>


### PR DESCRIPTION
Now with latest hirarchy change we have two project[java and zip] and we can't have the same identifier[<groupId>:<artifactId>:<version, com.cybersource:cybersource-sdk-java:6.1.0] for [C:\GitJavaSdk\zip\pom.xml, C:\GitJavaSdk\java\pom.xml]}. 
Hence using different identifier com.cybersource:cybersource-sdk-zip:6.1.0 for zip project.