### PR TITLE
Support non-ASCII chars

### DIFF
--- a/java/src/main/java/com/cybersource/ws/client/Utility.java
+++ b/java/src/main/java/com/cybersource/ws/client/Utility.java
@@ -428,7 +428,7 @@ public class Utility {
         // themselves.
         return (("1".equals(hasEscapes) ||
                 "true".equalsIgnoreCase(hasEscapes))
-                ? dest.toString() : StringEscapeUtils.escapeHtml((dest.toString())));
+                ? dest.toString() : StringEscapeUtils.escapeXml((dest.toString())));
     }
 
     


### PR DESCRIPTION
By using the correct XML escaping, rather than HTML escaping.

There is no HTML involved in this app, only XML. The .escapeHtml method
produces entities like `&eacute;` for non-ASCII characters which the subsequent XML parser doesn't
recognize. Since this ends up as text in an XML element, technically
only <, >, and & are required to be escaped.

Obviates the need for passing `_has_escapes` and escaping yourself to
work around this to support non-ASCII characters, like in #21.

We'd appreciate it if there could be a new released published soon with this fix.