### PR TITLE
changing bounce castle provider version to 1.54

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ We have two ways to test, One is using maven tool and other is to download the z
 	    The Apache WSS4J project provides a Java implementation of the primary security standards for Web Services, namely the OASIS Web Services Security (WS-Security) specifications    
 	    from the OASIS Web Services Security TC.
 	    
-	2.) org.bouncycastle:bcprov-jdk15on:1.55
+	2.) org.bouncycastle:bcprov-jdk15on:1.54
 		This jar contains JCE provider and lightweight API for the Bouncy Castle Cryptography APIs for JDK 1.5 to JDK 1.8.
 	
 	3.) org.apache.santuario:xmlsec:1.5.8

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.55</version>
+            <version>1.54</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ws.security</groupId>

--- a/samples/nvp/pom.xml
+++ b/samples/nvp/pom.xml
@@ -27,7 +27,7 @@
       <dependency>
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcprov-jdk15on</artifactId>
-          <version>1.55</version>
+          <version>1.54</version>
       </dependency>
       <dependency>
           <groupId>org.apache.ws.security</groupId>

--- a/samples/xml/pom.xml
+++ b/samples/xml/pom.xml
@@ -27,7 +27,7 @@
       <dependency>
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcprov-jdk15on</artifactId>
-          <version>1.55</version>
+          <version>1.54</version>
       </dependency>
       <dependency>
           <groupId>org.apache.ws.security</groupId>

--- a/zip/README
+++ b/zip/README
@@ -117,7 +117,7 @@ Refer to our Developer's Guide for details <http://apps.cybersource.com/library/
 	    The Apache WSS4J project provides a Java implementation of the primary security standards for Web Services, namely the OASIS Web Services Security (WS-Security) specifications    
 	    from the OASIS Web Services Security TC.
 	    
-	2.) org.bouncycastle:bcprov-jdk15on:1.55
+	2.) org.bouncycastle:bcprov-jdk15on:1.54
 		This jar contains JCE provider and lightweight API for the Bouncy Castle Cryptography APIs for JDK 1.5 to JDK 1.8.
 	
 	3.) org.apache.santuario:xmlsec:1.5.8


### PR DESCRIPTION
1.55 seems to have some issues running on mac with java 1.6