### PR TITLE
RetryPattern config for http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ You do not need to download and build the source to use the SDK but if you want 
        
     h. "serverURL" config parameter will take precedence over sendToProduction and sendToAkamai config parameters. By default the "serverURL" configuration is commented out. 
     
-    i. Set allowRetry config parameter to "true/false" to enable retry mechanism. By default, allowRetry is set to true.
-       Set integer values for config parameter numberOfRetries &  retryInterval to configure the retry behavior. Refer to the "Retry Pattern" section below.
+    i. 	"allowRetry" config parameter will only work for HttpClient. Set allowRetry config parameter to "true" to enable retry mechanism and set merchant specific values for the retry.
+    	Set integer values for config parameter numberOfRetries & retryInterval. Retry Interval is time delay for next retry in seconds. number of retry parameter should be set between
+    	1 to 5 any other value will throw an Error Message. Refer to the "Retry Pattern" section below.
         
     j. Please refer to the accompanying documentation for the other optional properties that you may wish to specify.
 
@@ -180,10 +181,12 @@ We have two ways to test, One is using maven tool and other is to download the z
   
 ##RETRY PATTERN
 
-	Retry Pattern Allows to retry sending a failed request. To Enable or disable retry mechanism set the allowRetry config parameter to "true or false". 
-	By default, allowRetry is set to true. The system will retry the failed request multiple times as configured in the config parameter 'numberOfRetries'. 
-	numberOfRetries (Number of retries) should be set between 1 to 3. By default numberOfRetries will be set to 1. User can set a delay in between the retry 
-	attempts using the config parameter 'retryInterval'. The default value for this parameter is 10 which means a delay of 10 seconds between the retry attempts.
+	Retry Pattern Allows to retry sending a failed request and it will only work with useHttpClient=true, allowRetry flag enables the retry mechanism. 
+	set the value of allowRetry parameter to "TRUE/FALSE". Then the system will retry the failed request as many times as configured by the merchant 
+	in the config parameter 'numberOfRetries'. 
+	
+	numberOfRetries parameter value should be set between 0 to 5. By default the value for numberOfRetries will be 5. User can set a delay in between the retry attempts. 
+	Config parameter for this property is 'retryInterval' in cybs.property file. The default value for 'retryInterval' parameter is 5 which means a delay of 5 seconds.
 
 ##Third Party jars
 	1.) org.apache.ws.security.wss4j:1.6.19

--- a/java/src/main/java/com/cybersource/ws/client/Client.java
+++ b/java/src/main/java/com/cybersource/ws/client/Client.java
@@ -180,8 +180,11 @@ public class Client {
         boolean logSignedData = mc.getLogSignedData();
         if (!logSignedData) {
             logger.log(
-                    Logger.LT_REQUEST,
-                    mapToString(request, true, PCI.REQUEST));
+            		Logger.LT_REQUEST,
+            		"UUID   >  "+(mc.getUniqueKey()).toString() + "\n" +
+            		"Input request is" + "\n" +
+            		"======================================= \n"
+            		+ mapToString(request, true, PCI.REQUEST));
         }
         
         Document wrappedDoc = soapWrap(request, mc, builder,logger);

--- a/java/src/main/java/com/cybersource/ws/client/Connection.java
+++ b/java/src/main/java/com/cybersource/ws/client/Connection.java
@@ -91,33 +91,22 @@ abstract class Connection {
      */
     public Document post(Document request)
             throws ClientException, FaultException {
-    	for (int i=0; i<=mc.getNumberOfRetries(); i++) {
-			try {
-				postDocument(request);
-				break;
-			} catch (IOException e) {
-				logger.log(Logger.LT_INFO, "Attempt to post document failed. Number of retry attempts made " + i);
-				if(i==mc.getNumberOfRetries()) throw new ClientException(e, isRequestSent(), logger);
-				try {
-					Thread.sleep((long) mc.getRetryInterval());
-				}catch (InterruptedException ex) {
-					logger.log(Logger.LT_INFO, "Waiting for the next attempt to made after " +mc.getRetryInterval() );
-				} 
-			} catch (TransformerConfigurationException e) {
-				throw new ClientException(e, isRequestSent(), logger);
-			} catch (TransformerException e) {
-				throw new ClientException(e, isRequestSent(), logger);
-			}
-			
-		} 
-		checkForFault();
-   		try {
-			return parseReceivedDocument();
-		}catch (IOException e) {
-			throw new ClientException(e, isRequestSent(), logger);
-		}catch (SAXException e) {
-			throw new ClientException(e, isRequestSent(), logger);
-		}}
+        try {
+            postDocument(request);
+            checkForFault();
+            return (parseReceivedDocument());
+        } catch (IOException e) {
+            throw new ClientException(e, isRequestSent(), logger);
+        } catch (TransformerConfigurationException e) {
+            throw new ClientException(e, isRequestSent(), logger);
+        } catch (TransformerException e) {
+            throw new ClientException(e, isRequestSent(), logger);
+        } catch (SAXException e) {
+            throw new ClientException(e, isRequestSent(), logger);
+        }
+
+    }
+
 
     /**
      * Validate the Http response for any faults returned from the server. 

--- a/java/src/main/java/com/cybersource/ws/client/HttpClientConnection.java
+++ b/java/src/main/java/com/cybersource/ws/client/HttpClientConnection.java
@@ -189,7 +189,9 @@ class HttpClientConnection extends Connection {
      */
     private class MyRetryHandler implements HttpMethodRetryHandler {
        
-        //
+    	long retryWaitInterval=mc.getRetryInterval();
+ 	   	int maxRetries= mc.getNumberOfRetries();
+ 	   	
         // I copied this code from
         // http://jakarta.apache.org/commons/httpclient/exception-handling.html#HTTP%20transport%20safety
         // and changed the NoHttpResponseException case to
@@ -198,7 +200,7 @@ class HttpClientConnection extends Connection {
                 final HttpMethod method,
                 final IOException exception,
                 int executionCount) {
-            if (executionCount > 5) {
+            if (executionCount > maxRetries) {
                 // Do not retry if over max retry count
                 return false;
             }
@@ -210,6 +212,13 @@ class HttpClientConnection extends Connection {
             if (!method.isRequestSent()) {
                 // Retry if the request has not been sent fully or
                 // if it's OK to retry methods that have been sent
+            	try {
+         	        Thread.sleep(retryWaitInterval);
+         	        logger.log( Logger.LT_INFO+" Retrying Request -- ",mc.getUniqueKey().toString()+ " Retry Count -- "+executionCount);
+                 } catch (InterruptedException e) {
+         	        // TODO Auto-generated catch block
+         	        e.printStackTrace();
+                 }
                 return true;
             }
             // otherwise do not retry

--- a/java/src/main/java/com/cybersource/ws/client/XMLClient.java
+++ b/java/src/main/java/com/cybersource/ws/client/XMLClient.java
@@ -330,7 +330,10 @@ public class XMLClient {
         
     	if (!logSignedData) {
             logger.log(Logger.LT_REQUEST,
-                    Utility.nodeToString(doc, PCI.REQUEST));
+            		"UUID   >  "+(mc.getUniqueKey()).toString() + "\n" +
+            		"Input request is" + "\n" +
+            		"======================================= \n"
+                    + Utility.nodeToString(doc, PCI.REQUEST));
         }
 
         Document wrappedDoc = soapWrap(doc, mc, builder, logger);

--- a/java/src/main/resources/cybs.properties
+++ b/java/src/main/resources/cybs.properties
@@ -15,18 +15,20 @@ sendToAkamai=<-- Set it to true for Akamai -->
 
 #useHttpClient=false
 
+# Following configure parameters will only work with useHttpClient=true
+# "allow retry" property toggle value "true/false" to turn on /off the auto request retry. 
+# Number of retries is the number of attempts made to send the request. 
+# Retry interval is the wait time in between the attempts to send the request.
+# Retry count configuration, interval unit is in seconds.
+# Default values are for allowRetry=true, numberOfRetries=5 and retryInterval=5 seconds.
+allowRetry=true
+numberOfRetries=5
+retryInterval=5
+
 # Mechanism to differentiate whether Payload is encrypted or not
 useSignAndEncrypted=<-- Set it to true for MLE[MessageLevelEncryption] -->
 
 timeout=1000
-
-# allowRetry flag can be set to true to enable retry. numberOfRetries is the number of attempts made to send 
-# the request. retryInterval is the wait time in between the attempts to send the request.
-# Retry count configuration, interval unit is in seconds.
-# Default values for allowRetry=true, numberOfRetries=1 and retryInterval=10seconds.
-allowRetry=true
-numberOfRetries=1
-retryInterval=10
 
 # logging should normally be disabled in production as it would slow down the
 # processing.  Enable it only when troubleshooting an issue.

--- a/java/src/test/resources/test_cybs.properties
+++ b/java/src/test/resources/test_cybs.properties
@@ -15,18 +15,20 @@ sendToAkamai=true
 
 #useHttpClient=false
 
+# Following configure parameters will only work with useHttpClient=true
+# "allow retry" property toggle value "true/false" to turn on /off the auto request retry. 
+# Number of retries is the number of attempts made to send the request. 
+# Retry interval is the wait time in between the attempts to send the request.
+# Retry count configuration, interval unit is in seconds.
+# Default values are for allowRetry=true, numberOfRetries=5 and retryInterval=5 seconds.
+allowRetry=true
+numberOfRetries=5
+retryInterval=5
+
 # Mechanism to differentiate whether Payload is encrypted or not
 useSignAndEncrypted=false
 
 timeout=1000
-
-# allowRetry flag can be set to true to enable retry. numberOfRetries is the number of attempts made to send 
-# the request. retryInterval is the wait time in between the attempts to send the request.
-# Retry count configuration, interval unit is in seconds.
-# Default values for allowRetry=true, numberOfRetries=1 and retryInterval=10seconds.
-allowRetry=true
-numberOfRetries=1
-retryInterval=10
 
 # logging should normally be disabled in production as it would slow down the
 # processing.  Enable it only when troubleshooting an issue.

--- a/samples/nvp/cybs.properties
+++ b/samples/nvp/cybs.properties
@@ -15,18 +15,20 @@ sendToAkamai=true
 
 #useHttpClient=false
 
+# Following configure parameters will only work with useHttpClient=true
+# "allow retry" property toggle value "true/false" to turn on /off the auto request retry. 
+# Number of retries is the number of attempts made to send the request. 
+# Retry interval is the wait time in between the attempts to send the request.
+# Retry count configuration, interval unit is in seconds.
+# Default values are for allowRetry=true, numberOfRetries=5 and retryInterval=5 seconds.
+allowRetry=true
+numberOfRetries=5
+retryInterval=5
+
 # Mechanism to differentiate whether Payload is encrypted or not
 useSignAndEncrypted=false
 
 timeout=1000
-
-# allowRetry flag can be set to true to enable retry. numberOfRetries is the number of attempts made to send 
-# the request. retryInterval is the wait time in between the attempts to send the request.
-# Retry count configuration, interval unit is in seconds.
-# Default values for allowRetry=true, numberOfRetries=1 and retryInterval=10seconds.
-allowRetry=true
-numberOfRetries=1
-retryInterval=10
 
 # logging should normally be disabled in production as it would slow down the
 # processing.  Enable it only when troubleshooting an issue.

--- a/samples/xml/cybs.properties
+++ b/samples/xml/cybs.properties
@@ -15,18 +15,20 @@ sendToAkamai=true
 
 #useHttpClient=false
 
+# Following configure parameters will only work with useHttpClient=true
+# "allow retry" property toggle value "true/false" to turn on /off the auto request retry. 
+# Number of retries is the number of attempts made to send the request. 
+# Retry interval is the wait time in between the attempts to send the request.
+# Retry count configuration, interval unit is in seconds.
+# Default values are for allowRetry=true, numberOfRetries=5 and retryInterval=5 seconds.
+allowRetry=true
+numberOfRetries=5
+retryInterval=5
+
 # Mechanism to differentiate whether payload is encrypted or not
 useSignAndEncrypted=false
 
 timeout=1000
-
-# allowRetry flag can be set to true to enable retry. numberOfRetries is the number of attempts made to send 
-# the request. retryInterval is the wait time in between the attempts to send the request.
-# Retry count configuration, interval unit is in seconds.
-# Default values for allowRetry=true, numberOfRetries=1 and retryInterval=10seconds.
-allowRetry=true
-numberOfRetries=1
-retryInterval=10
 
 # logging should normally be disabled in production as it would slow down the
 # processing.  Enable it only when troubleshooting an issue.

--- a/zip/README
+++ b/zip/README
@@ -61,8 +61,9 @@ Refer to our Developer's Guide for details <http://apps.cybersource.com/library/
        
     h. "serverURL" config parameter will take precedence over sendToProduction and sendToAkamai config parameters. By default the "serverURL" configuration is commented out. 
     
-    i. Set allowRetry config parameter to "true/false" to enable retry mechanism. By default, allowRetry is set to true.
-       Set integer values for config parameter numberOfRetries &  retryInterval to configure the retry behavior. Refer to the "Retry Pattern" section below.
+    i. "allowRetry" config parameter will only work for HttpClient. Set allowRetry config parameter to "true" to enable retry mechanism and set merchant specific values for the retry. 
+       Set integer values for config parameter numberOfRetries & retryInterval. Retry Interval is time delay for next retry in seconds. number of retry parameter should be set between
+       1 to 5 any other value will throw an Error Message. Refer to the "Retry Pattern" section below.
         
     j. Please refer to the accompanying documentation for the other optional properties that you may wish to specify.
 
@@ -118,10 +119,12 @@ Refer to our Developer's Guide for details <http://apps.cybersource.com/library/
 
 ##RETRY PATTERN
 	
-	Retry Pattern Allows to retry sending a failed request. To Enable or disable retry mechanism set the allowRetry config parameter to "true or false". 
-	By default, allowRetry is set to true. The system will retry the failed request multiple times as configured in the config parameter 'numberOfRetries'. 
-	numberOfRetries (Number of retries) should be set between 1 to 3. By default numberOfRetries will be set to 1. User can set a delay in between the retry 
-	attempts using the config parameter 'retryInterval'. The default value for this parameter is 10 which means a delay of 10 seconds between the retry attempts.
+	Retry Pattern Allows to retry sending a failed request and it will only work with useHttpClient=true, allowRetry flag enables the retry mechanism. 
+	set the value of allowRetry parameter to "TRUE/FALSE". Then the system will retry the failed request as many times as configured by the merchant 
+	in the config parameter 'numberOfRetries'. 
+	
+	numberOfRetries parameter value should be set between 0 to 5. By default the value for numberOfRetries will be 5. User can set a delay in between the retry attempts. 
+	Config parameter for this property is 'retryInterval' in cybs.property file. The default value for 'retryInterval' parameter is 5 which means a delay of 5 seconds.
 	
 ##Third Party jars
 	1.) org.apache.ws.security.wss4j:1.6.19


### PR DESCRIPTION
1) Set useHttpClient to true to use Apache Http client.
2) Set allowRetry config parameter to "True/False" to enable retry mechanism for HttpClient. By default it is set to true.
3) Set integer values for config parameter "numberOfRetries" & "retryInterval". Numberofretries parameter should be set between 0 to 5. "retryInterval" is in seconds
4) By default "numberOfRetries" is set to 5.
5) Default value of "retryInterval" is 5 seconds.