### PR TITLE
Add the abilty to set a connection timeout separate from socket timeout

### DIFF
--- a/java/src/main/java/com/cybersource/ws/client/ConnectionHelper.java
+++ b/java/src/main/java/com/cybersource/ws/client/ConnectionHelper.java
@@ -48,10 +48,9 @@ class ConnectionHelper {
      * @param con
      * @param timeout
      */
-    public static void setTimeout(HttpURLConnection con, int timeout) {
-        int timeoutInMS = timeout * 1000;
-        con.setConnectTimeout(timeoutInMS);
-        con.setReadTimeout(timeoutInMS);
+    public static void setTimeout(HttpURLConnection con, int connectionTimeout, int timeout) {
+        con.setConnectTimeout(connectionTimeout * 1000);
+        con.setReadTimeout(timeout * 1000);
     }
 
     /**

--- a/java/src/main/java/com/cybersource/ws/client/HttpClientConnection.java
+++ b/java/src/main/java/com/cybersource/ws/client/HttpClientConnection.java
@@ -61,7 +61,7 @@ class HttpClientConnection extends Connection {
             TransformerException, MalformedURLException,
             ProtocolException {
         HttpClient httpClient = new HttpClient();
-        setTimeout(httpClient, mc.getTimeout() * 1000);
+        setTimeout(httpClient, mc.getConnectionTimeout() * 1000, mc.getTimeout() * 1000);
         setProxy(httpClient);
 
         String serverURL = mc.getEffectiveServerURL();
@@ -126,10 +126,10 @@ class HttpClientConnection extends Connection {
      * @param httpClient
      * @param timeoutInMs
      */
-    private void setTimeout(HttpClient httpClient, int timeoutInMs) {
+    private void setTimeout(HttpClient httpClient, int connectionTimeoutInMs, int timeoutInMs) {
         HttpConnectionManagerParams params
                 = httpClient.getHttpConnectionManager().getParams();
-        params.setConnectionTimeout(timeoutInMs);
+        params.setConnectionTimeout(connectionTimeoutInMs);
         params.setSoTimeout(timeoutInMs);
     }
 

--- a/java/src/main/java/com/cybersource/ws/client/JDKHttpURLConnection.java
+++ b/java/src/main/java/com/cybersource/ws/client/JDKHttpURLConnection.java
@@ -59,7 +59,7 @@ class JDKHttpURLConnection extends Connection {
         con = ConnectionHelper.openConnection(url, mc);
         con.setRequestMethod("POST");
         con.setDoOutput(true);
-        ConnectionHelper.setTimeout(con, mc.getTimeout());
+        ConnectionHelper.setTimeout(con, mc.getConnectionTimeout(), mc.getTimeout());
 
         OutputStream out = con.getOutputStream();
         byte[] requestBytes = documentToByteArray(request);

--- a/java/src/main/java/com/cybersource/ws/client/MerchantConfig.java
+++ b/java/src/main/java/com/cybersource/ws/client/MerchantConfig.java
@@ -57,6 +57,7 @@ public class MerchantConfig {
     private int logMaximumSize;
     private boolean useHttpClient;
     private int timeout;
+    private int connectionTimeout;
     private String proxyHost;
     private int proxyPort;
     private String proxyUser;
@@ -157,6 +158,8 @@ public class MerchantConfig {
         return timeout;
     }
 
+    public int getConnectionTimeout() { return connectionTimeout; }
+
     public String getProxyHost() {
         return proxyHost;
     }
@@ -253,6 +256,7 @@ public class MerchantConfig {
         useHttpClient = getBooleanProperty(merchantID, "useHttpClient", ConnectionHelper.getDefaultUseHttpClient());
 
         timeout = getIntegerProperty(merchantID, "timeout", DEFAULT_TIMEOUT);
+        connectionTimeout = getIntegerProperty(merchantID, "connectionTimeout", timeout);
         proxyHost = getProperty(merchantID, "proxyHost");
         proxyPort = getIntegerProperty(merchantID, "proxyPort", DEFAULT_PROXY_PORT);
         proxyUser = getProperty(merchantID, "proxyUser");
@@ -467,6 +471,7 @@ public class MerchantConfig {
             appendPair(sb, "RetryInterval", retryInterval);
         }
         appendPair(sb, "timeout", timeout);
+        appendPair(sb, "connectionTimeout", connectionTimeout);
         if (proxyHost != null) {
             appendPair(sb, "proxyHost", proxyHost);
             appendPair(sb, "proxyPort", proxyPort);

--- a/java/src/main/resources/cybs.properties
+++ b/java/src/main/resources/cybs.properties
@@ -28,7 +28,11 @@ retryInterval=5
 # Mechanism to differentiate whether Payload is encrypted or not
 useSignAndEncrypted=<-- Set it to true for MLE[MessageLevelEncryption] -->
 
-timeout=1000
+# Timeout is in seconds
+timeout=20
+
+# connection timeout if not present will default to timeout above.
+connectionTimeout=5
 
 # logging should normally be disabled in production as it would slow down the
 # processing.  Enable it only when troubleshooting an issue.

--- a/java/src/test/resources/test_cybs.properties
+++ b/java/src/test/resources/test_cybs.properties
@@ -28,7 +28,8 @@ retryInterval=5
 # Mechanism to differentiate whether Payload is encrypted or not
 useSignAndEncrypted=false
 
-timeout=1000
+timeout=100
+connectionTimeout=100
 
 # logging should normally be disabled in production as it would slow down the
 # processing.  Enable it only when troubleshooting an issue.

--- a/samples/nvp/cybs.properties
+++ b/samples/nvp/cybs.properties
@@ -28,7 +28,8 @@ retryInterval=5
 # Mechanism to differentiate whether Payload is encrypted or not
 useSignAndEncrypted=false
 
-timeout=1000
+timeout=100
+connectionTimeout=100
 
 # logging should normally be disabled in production as it would slow down the
 # processing.  Enable it only when troubleshooting an issue.

--- a/samples/xml/cybs.properties
+++ b/samples/xml/cybs.properties
@@ -4,6 +4,7 @@ keyAlias=
 keyPassword=
 targetAPIVersion=1.129
 
+
 # the following flags can be used to control the endpoint to which requests will be sent. 
 # Set sendToProduction=true to send requests to Cybersource production environment.
 # Set sendToAkamai=true to send requests through Akamai to Cybersource.
@@ -28,7 +29,8 @@ retryInterval=5
 # Mechanism to differentiate whether payload is encrypted or not
 useSignAndEncrypted=false
 
-timeout=1000
+timeout=100
+connectionTimeout=100
 
 # logging should normally be disabled in production as it would slow down the
 # processing.  Enable it only when troubleshooting an issue.


### PR DESCRIPTION
This allows the connection timeout to be configured differently from the socket timeout.

Getting a connection should be relatively quick and you don't want to tie that to the same timeout as waiting for a request to process.

This makes the retry functionality much better as well as it only retries on connection failures.