### PR TITLE
Now user can load jks or cacerts file at runtime similar like  p12 file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ You do not need to download and build the source to use the SDK but if you want 
     - `serverURL` config parameter will take precedence over `sendToProduction` and `sendToAkamai` config parameters. By default the `serverURL` configuration is commented out.
     - if `enablejdkcert` parameter is set to true, certificates will be read from the JKS file specified at keysDirectory location. The JKS file should be of the same name as specified in keyFilename.
       - To know how to convert p12 to JKS refer the JKS creation section of this document.
-    - `enableCacerts` property is considered only if `enablejdkcert` is set to true. If `enableCacerts` is set to true, certificates will be read from the cacerts folder under the JDK.
+    - If `enableCacerts` is set to true, certificates will be read from the cacerts folder under the JDKxx\jre\lib\security.
+       Also point keysDirectory to " C:\\Program Files\\Java\\jdk1.8.0_152\\jre\\lib\\security " and keyFilename=cacerts   
     - if `certificateCacheEnabled` parameter is set to false (default is true), the p12 certificate of a merchant will be reloaded from filesystem every time a transaction is made 
     - `allowRetry` config parameter will only work for HttpClient. Set `allowRetry` config parameter to "true" to enable retry mechanism and set merchant specific values for the retry.
     - Set integer values for config parameter `numberOfRetries` *and* `retryInterval`. Retry Interval is time delay for next retry in seconds.
@@ -137,6 +138,15 @@ keytool -list -v -keystore <Your_keystore_name>`
 - It should have two entries.
   - The first entry should contain a chain of two certificates - `CyberSourceCertAuth` and <Merchant_ID> with alias name <Merchant_ID>
   - Second entry should be for `CyberSource_SJC_US` certificate with alias name as CyberSource_SJC_US
+  
+Keep the .jks file under C:\Program Files\Java\jdk1.8.0_152\jre\lib\security folder
+
+Give full access permission to cacerts file.
+
+run the command 
+
+keytool -importkeystore -alias keyfilealias -srckeystore keyfilealias.jks -keystore cacerts
+  
 
 ## Message Level Encryption
 CyberSource supports Message Level Encryption (MLE) for Simple Order API. Message level encryption conforms to the SOAP Security 1.0 specification published by the OASIS standards group. 

--- a/java/src/main/java/com/cybersource/ws/client/Identity.java
+++ b/java/src/main/java/com/cybersource/ws/client/Identity.java
@@ -57,7 +57,7 @@ public class Identity {
         if(this.logger == null){
         	this.logger=logger;
         }
-        if(merchantConfig.isJdkCertEnabled()){
+        if(merchantConfig.isJdkCertEnabled() || merchantConfig.isCacertEnabled()){
             setupJdkServerCerts();
         }
         else{

--- a/java/src/main/java/com/cybersource/ws/client/MerchantConfig.java
+++ b/java/src/main/java/com/cybersource/ws/client/MerchantConfig.java
@@ -22,6 +22,9 @@ import java.io.File;
 import java.text.MessageFormat;
 import java.util.Properties;
 import java.util.UUID;
+
+import javax.swing.plaf.basic.BasicTreeUI.SelectionModelPropertyChangeHandler;
+
 import org.apache.commons.lang3.StringUtils;
 /**
  * An internal class used by the clients to hold and derive the properties
@@ -329,6 +332,18 @@ public class MerchantConfig {
                 throw new ConfigException("Invalid value of numberOfRetries and/or retryInterval");
             }
         }
+        
+        if(isCacertEnabled()){
+        String keyPath=this.getKeysDirectory();
+        String keysFilename=this.getKeyFilename();
+        if(!(keyPath == null)){
+        	keysDirectory=keyPath;
+        }
+        if(!(keysFilename == null)){
+        	keyFilename=keysFilename;
+        	
+        }
+      }
     }
     
     /**

--- a/java/src/main/java/com/cybersource/ws/client/SecurityUtil.java
+++ b/java/src/main/java/com/cybersource/ws/client/SecurityUtil.java
@@ -99,6 +99,10 @@ public class SecurityUtil {
                 logger.log(Logger.LT_INFO," Loading the certificate from JDK Cert");
                 SecurityUtil.readJdkCert(merchantConfig,logger);
             }
+            else if(merchantConfig.isCacertEnabled()){
+                logger.log(Logger.LT_INFO," Loading the certificate from JRE security cacert file");
+                SecurityUtil.readJdkCert(merchantConfig,logger);
+            }
             else{
                 logger.log(Logger.LT_INFO,"Loading the certificate from p12 file ");
                 readAndStoreCertificateAndPrivateKey(merchantConfig, logger);
@@ -264,18 +268,17 @@ public class SecurityUtil {
     public static void readJdkCert(MerchantConfig merchantConfig, Logger logger) throws SignEncryptException, SignException{
         KeyStore keystore=null;
         
-        String path=merchantConfig.getKeysDirectory()+"/"+merchantConfig.getKeyFilename();
         String pass=merchantConfig.getKeyPassword();
         
         if (merchantConfig.isCacertEnabled()){
-            path = System.getProperty("java.home") + "/lib/security/cacerts".replace('/', File.separatorChar);
+        	String path = System.getProperty("java.home") + "/lib/security/cacerts".replace('/', File.separatorChar);
             loadJavaKeystore(path, merchantConfig,logger);
             
         }
         
         else{
             try{
-                FileInputStream is = new FileInputStream(path);
+                FileInputStream is = new FileInputStream(merchantConfig.getKeyFile());
                 keystore = KeyStore.getInstance(KeyStore.getDefaultType());
                 keystore.load(is, pass.toCharArray());
             }

--- a/java/src/main/resources/cybs.properties
+++ b/java/src/main/resources/cybs.properties
@@ -38,7 +38,7 @@ retryInterval=5
 enableJdkCert=false
 
 # if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert. This property will be considered only if enableJDKcert is set to true.
+# And it will read from JDK cert.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/java/src/test/resources/test_cybs.properties
+++ b/java/src/test/resources/test_cybs.properties
@@ -36,7 +36,7 @@ retryInterval=5
 enableJdkCert=false
 
 # if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert. This property will be considered only if enableJDKcert is set to true.
+# And it will read from JDK cert.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/samples/nvp/cybs.properties
+++ b/samples/nvp/cybs.properties
@@ -39,7 +39,7 @@ retryInterval=5
 enableJdkCert=false
 
 # if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert. This property will be considered only if enableJDKcert is set to true.
+# And it will read from JDK cert.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/samples/xml/cybs.properties
+++ b/samples/xml/cybs.properties
@@ -39,7 +39,7 @@ retryInterval=5
 enableJdkCert=false
 
 # if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert. This property will be considered only if enableJDKcert is set to true.
+# And it will read from JDK cert.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=


### PR DESCRIPTION
Now user can load jks or cacerts file at runtime similar like  p12 file. System is capable to read the new JSK or cacerts file at runtime . Also to removed the dependency of enableJdkCert=true while loading the cacerts file . So system can read cacerts file even enableJdkCert=false . Details mentioned in README.MD file