### PR TITLE
Now user can load jks or cacerts file at runtime similar like p12 file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,9 @@ You do not need to download and build the source to use the SDK but if you want 
       - `sendToProduction` is initially set to false. Set it to true only when you are ready to send live transactions.
     - Set `sendToAkamai` config parameter with toggle value "true/false" to turn on/off routing requests through Akamai to Cybersource. By default, it is set to true.
     - `serverURL` config parameter will take precedence over `sendToProduction` and `sendToAkamai` config parameters. By default the `serverURL` configuration is commented out.
-    - if `enablejdkcert` parameter is set to true, certificates will be read from the JKS file specified at keysDirectory location. The JKS file should be of the same name as specified in keyFilename.
+    - if `enableJdkcert` parameter is set to true, certificates will be read from the JKS file specified at keysDirectory location. The JKS file should be of the same name as specified in keyFilename.
       - To know how to convert p12 to JKS refer the JKS creation section of this document.
-    - If enableCacert property is enabled then it means the certificates are kept under the keysDirectory path.
-       By default, keysDirectory path is set to Java Installation cacerts location.
+    - If 'enableCacert' property parameter is set to true, certificates will be read from the cacerts file specified at keysDirectory location.If keysDirectory path is not set,certificate will be loaded from Java Installation cacerts file. The cacerts file should be of the same name as specified in keyFilename.
     - if `certificateCacheEnabled` parameter is set to false (default is true), the p12 certificate of a merchant will be reloaded from filesystem every time a transaction is made 
     - `allowRetry` config parameter will only work for HttpClient. Set `allowRetry` config parameter to "true" to enable retry mechanism and set merchant specific values for the retry.
     - Set integer values for config parameter `numberOfRetries` *and* `retryInterval`. Retry Interval is time delay for next retry in seconds.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dependencies {
 ## Requirements
 - Java SDK 1.6 and later  
 - Maven 3 and later  
-- It is recommended to use Unlimited Strength Jurisdiction Policy files from OracleÂ® (US_export_policy.jar and local_policy.jar) for appropriate JAVA version. For JAVA 7, it is available at http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html
+- It is recommended to use Unlimited Strength Jurisdiction Policy files from Oracle® (US_export_policy.jar and local_policy.jar) for appropriate JAVA version. For JAVA 7, it is available at http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html
 
 ## Prerequisites
 ### CyberSource Evaluation account
@@ -37,7 +37,7 @@ Create security keys in the [Enterprise Business Center](https://ebctest.cyberso
 - Refer to our [Developer Guide](http://apps.cybersource.com/library/documentation/dev_guides/security_keys/html/wwhelp/wwhimpl/js/html/wwhelp.htm#href=securityKeys_SO_API.4.1.html) for details.
 
 ### JCE Unlimited Strength Jars
-Replace your Java installationâ€™s existing security policy files with the new ones you downloaded from the Oracle site:
+Replace your Java installation’s existing security policy files with the new ones you downloaded from the Oracle site:
 - Locate your existing US_export_policy.jar and local_policy.jar files in the $JAVA_HOME/jre/lib/security directory.
 - Rename or move your existing files to another directory.
 - Copy the new US_export_policy.jar and local_policy.jar that you downloaded from Oracle to the $JAVA_HOME/jre/lib/security directory.  
@@ -60,8 +60,8 @@ You do not need to download and build the source to use the SDK but if you want 
     - `serverURL` config parameter will take precedence over `sendToProduction` and `sendToAkamai` config parameters. By default the `serverURL` configuration is commented out.
     - if `enablejdkcert` parameter is set to true, certificates will be read from the JKS file specified at keysDirectory location. The JKS file should be of the same name as specified in keyFilename.
       - To know how to convert p12 to JKS refer the JKS creation section of this document.
-   - If `enableCacerts` is set to true, certificates will be read from the cacerts folder under the $JAVA_HOME/jre/lib/security.
-       Also point keysDirectory to  $JAVA_HOME/jre/lib/security and keyFilename=cacerts .
+    - If `enableCacerts` is set to true, certificates will be read from the cacerts folder under the " %JAVA_HOME\jre\lib\security ".
+       Also point keysDirectory to " %JAVA_HOME\\jre\\lib\\security " and keyFilename=cacerts .
     - if `certificateCacheEnabled` parameter is set to false (default is true), the p12 certificate of a merchant will be reloaded from filesystem every time a transaction is made 
     - `allowRetry` config parameter will only work for HttpClient. Set `allowRetry` config parameter to "true" to enable retry mechanism and set merchant specific values for the retry.
     - Set integer values for config parameter `numberOfRetries` *and* `retryInterval`. Retry Interval is time delay for next retry in seconds.
@@ -138,17 +138,18 @@ keytool -list -v -keystore <Your_keystore_name>`
 - It should have two entries.
   - The first entry should contain a chain of two certificates - `CyberSourceCertAuth` and <Merchant_ID> with alias name <Merchant_ID>
   - Second entry should be for `CyberSource_SJC_US` certificate with alias name as CyberSource_SJC_US
-
+  
+  
 ## Message Level Encryption
 CyberSource supports Message Level Encryption (MLE) for Simple Order API. Message level encryption conforms to the SOAP Security 1.0 specification published by the OASIS standards group. 
 
 ### Authentication Details
     Message level encryption authenticates using the same mechanism as signed SOAP messages. The signature creation involves utilizing the merchants private key which combined with a hash of the message to be signed, can be validated with the merchants certificate and the message which was signed. 
-    The merchant certificate is included in the SOAP message for both signature and message level encryption. Message level encryption, encrypts a temporary message key for a specific recipient. This is done by encrypting the temporary message key with the recipientâ€™s public certificate. Therefore only the party holding the private key (CyberSource) can decrypt the temporary message key. The merchant sending the request must be a valid merchant for the environment which the message is being processed in. After validating the merchant and retrieving the CyberSource copy of the merchant certificate from our database, these additional authentication steps are performed:
+    The merchant certificate is included in the SOAP message for both signature and message level encryption. Message level encryption, encrypts a temporary message key for a specific recipient. This is done by encrypting the temporary message key with the recipient’s public certificate. Therefore only the party holding the private key (CyberSource) can decrypt the temporary message key. The merchant sending the request must be a valid merchant for the environment which the message is being processed in. After validating the merchant and retrieving the CyberSource copy of the merchant certificate from our database, these additional authentication steps are performed:
     1.	The certificate sent in the message must have valid trust chain with the CyberSource certificate authority as the root signer.
     2.	A certificate belonging to the merchant which sent the message must exist within our database, having the exact serial number of the certificate provided. 
     3.	Our record of the certificate must have a valid start and end date for the transaction time sent.
-    4.	Our record of the certificate must have a â€œactiveâ€� state (ie. Not deactivated by support).
+    4.	Our record of the certificate must have a “active” state (ie. Not deactivated by support).
     5.	If merchant is reseller, the merchant must allow reseller to act upon their behalf and reseller must be configured as a reseller and the provided merchant must be configured as a merchant of this reseller. Additionally all above authorizations apply.
 
 ### Cryptography Algorithms

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ You do not need to download and build the source to use the SDK but if you want 
     - `serverURL` config parameter will take precedence over `sendToProduction` and `sendToAkamai` config parameters. By default the `serverURL` configuration is commented out.
     - if `enablejdkcert` parameter is set to true, certificates will be read from the JKS file specified at keysDirectory location. The JKS file should be of the same name as specified in keyFilename.
       - To know how to convert p12 to JKS refer the JKS creation section of this document.
-    - `enableCacerts` property is considered only if `enablejdkcert` is set to true. If `enableCacerts` is set to true, certificates will be read from the cacerts folder under the JDK.
+   - If `enableCacerts` is set to true, certificates will be read from the cacerts folder under the JDKxx\jre\lib\security.
+       Also point keysDirectory to " C:\\Program Files\\Java\\jdk1.8.0_152\\jre\\lib\\security " and keyFilename=cacerts   in case of windows environment
     - if `certificateCacheEnabled` parameter is set to false (default is true), the p12 certificate of a merchant will be reloaded from filesystem every time a transaction is made 
     - `allowRetry` config parameter will only work for HttpClient. Set `allowRetry` config parameter to "true" to enable retry mechanism and set merchant specific values for the retry.
     - Set integer values for config parameter `numberOfRetries` *and* `retryInterval`. Retry Interval is time delay for next retry in seconds.
@@ -137,6 +138,10 @@ keytool -list -v -keystore <Your_keystore_name>`
 - It should have two entries.
   - The first entry should contain a chain of two certificates - `CyberSourceCertAuth` and <Merchant_ID> with alias name <Merchant_ID>
   - Second entry should be for `CyberSource_SJC_US` certificate with alias name as CyberSource_SJC_US
+  -Keep the .jks file under C:\Program Files\Java\jdk1.8.0_152\jre\lib\security folder
+  -Give full access permission to cacerts file.
+   run the command 
+keytool -importkeystore -alias keyfilealias -srckeystore keyfilealias.jks -keystore cacerts
 
 ## Message Level Encryption
 CyberSource supports Message Level Encryption (MLE) for Simple Order API. Message level encryption conforms to the SOAP Security 1.0 specification published by the OASIS standards group. 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ You do not need to download and build the source to use the SDK but if you want 
     - `serverURL` config parameter will take precedence over `sendToProduction` and `sendToAkamai` config parameters. By default the `serverURL` configuration is commented out.
     - if `enablejdkcert` parameter is set to true, certificates will be read from the JKS file specified at keysDirectory location. The JKS file should be of the same name as specified in keyFilename.
       - To know how to convert p12 to JKS refer the JKS creation section of this document.
-    - If `enableCacerts` is set to true, certificates will be read from the cacerts folder under the " %JAVA_HOME\jre\lib\security ".
-       Also point keysDirectory to " %JAVA_HOME\\jre\\lib\\security " and keyFilename=cacerts .
+    - If enableCacert property is enabled then it means the certificates are kept under the keysDirectory path.
+       By default, keysDirectory path is set to Java Installation cacerts location.
     - if `certificateCacheEnabled` parameter is set to false (default is true), the p12 certificate of a merchant will be reloaded from filesystem every time a transaction is made 
     - `allowRetry` config parameter will only work for HttpClient. Set `allowRetry` config parameter to "true" to enable retry mechanism and set merchant specific values for the retry.
     - Set integer values for config parameter `numberOfRetries` *and* `retryInterval`. Retry Interval is time delay for next retry in seconds.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dependencies {
 ## Requirements
 - Java SDK 1.6 and later  
 - Maven 3 and later  
-- It is recommended to use Unlimited Strength Jurisdiction Policy files from Oracle® (US_export_policy.jar and local_policy.jar) for appropriate JAVA version. For JAVA 7, it is available at http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html
+- It is recommended to use Unlimited Strength Jurisdiction Policy files from OracleÂ® (US_export_policy.jar and local_policy.jar) for appropriate JAVA version. For JAVA 7, it is available at http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html
 
 ## Prerequisites
 ### CyberSource Evaluation account
@@ -37,7 +37,7 @@ Create security keys in the [Enterprise Business Center](https://ebctest.cyberso
 - Refer to our [Developer Guide](http://apps.cybersource.com/library/documentation/dev_guides/security_keys/html/wwhelp/wwhimpl/js/html/wwhelp.htm#href=securityKeys_SO_API.4.1.html) for details.
 
 ### JCE Unlimited Strength Jars
-Replace your Java installation’s existing security policy files with the new ones you downloaded from the Oracle site:
+Replace your Java installationâ€™s existing security policy files with the new ones you downloaded from the Oracle site:
 - Locate your existing US_export_policy.jar and local_policy.jar files in the $JAVA_HOME/jre/lib/security directory.
 - Rename or move your existing files to another directory.
 - Copy the new US_export_policy.jar and local_policy.jar that you downloaded from Oracle to the $JAVA_HOME/jre/lib/security directory.  
@@ -60,8 +60,8 @@ You do not need to download and build the source to use the SDK but if you want 
     - `serverURL` config parameter will take precedence over `sendToProduction` and `sendToAkamai` config parameters. By default the `serverURL` configuration is commented out.
     - if `enablejdkcert` parameter is set to true, certificates will be read from the JKS file specified at keysDirectory location. The JKS file should be of the same name as specified in keyFilename.
       - To know how to convert p12 to JKS refer the JKS creation section of this document.
-   - If `enableCacerts` is set to true, certificates will be read from the cacerts folder under the JDKxx\jre\lib\security.
-       Also point keysDirectory to " C:\\Program Files\\Java\\jdk1.8.0_152\\jre\\lib\\security " and keyFilename=cacerts   in case of windows environment
+   - If `enableCacerts` is set to true, certificates will be read from the cacerts folder under the $JAVA_HOME/jre/lib/security.
+       Also point keysDirectory to  $JAVA_HOME/jre/lib/security and keyFilename=cacerts .
     - if `certificateCacheEnabled` parameter is set to false (default is true), the p12 certificate of a merchant will be reloaded from filesystem every time a transaction is made 
     - `allowRetry` config parameter will only work for HttpClient. Set `allowRetry` config parameter to "true" to enable retry mechanism and set merchant specific values for the retry.
     - Set integer values for config parameter `numberOfRetries` *and* `retryInterval`. Retry Interval is time delay for next retry in seconds.
@@ -138,21 +138,17 @@ keytool -list -v -keystore <Your_keystore_name>`
 - It should have two entries.
   - The first entry should contain a chain of two certificates - `CyberSourceCertAuth` and <Merchant_ID> with alias name <Merchant_ID>
   - Second entry should be for `CyberSource_SJC_US` certificate with alias name as CyberSource_SJC_US
-  -Keep the .jks file under C:\Program Files\Java\jdk1.8.0_152\jre\lib\security folder
-  -Give full access permission to cacerts file.
-   run the command 
-keytool -importkeystore -alias keyfilealias -srckeystore keyfilealias.jks -keystore cacerts
 
 ## Message Level Encryption
 CyberSource supports Message Level Encryption (MLE) for Simple Order API. Message level encryption conforms to the SOAP Security 1.0 specification published by the OASIS standards group. 
 
 ### Authentication Details
     Message level encryption authenticates using the same mechanism as signed SOAP messages. The signature creation involves utilizing the merchants private key which combined with a hash of the message to be signed, can be validated with the merchants certificate and the message which was signed. 
-    The merchant certificate is included in the SOAP message for both signature and message level encryption. Message level encryption, encrypts a temporary message key for a specific recipient. This is done by encrypting the temporary message key with the recipient’s public certificate. Therefore only the party holding the private key (CyberSource) can decrypt the temporary message key. The merchant sending the request must be a valid merchant for the environment which the message is being processed in. After validating the merchant and retrieving the CyberSource copy of the merchant certificate from our database, these additional authentication steps are performed:
+    The merchant certificate is included in the SOAP message for both signature and message level encryption. Message level encryption, encrypts a temporary message key for a specific recipient. This is done by encrypting the temporary message key with the recipientâ€™s public certificate. Therefore only the party holding the private key (CyberSource) can decrypt the temporary message key. The merchant sending the request must be a valid merchant for the environment which the message is being processed in. After validating the merchant and retrieving the CyberSource copy of the merchant certificate from our database, these additional authentication steps are performed:
     1.	The certificate sent in the message must have valid trust chain with the CyberSource certificate authority as the root signer.
     2.	A certificate belonging to the merchant which sent the message must exist within our database, having the exact serial number of the certificate provided. 
     3.	Our record of the certificate must have a valid start and end date for the transaction time sent.
-    4.	Our record of the certificate must have a “active” state (ie. Not deactivated by support).
+    4.	Our record of the certificate must have a â€œactiveâ€� state (ie. Not deactivated by support).
     5.	If merchant is reseller, the merchant must allow reseller to act upon their behalf and reseller must be configured as a reseller and the provided merchant must be configured as a merchant of this reseller. Additionally all above authorizations apply.
 
 ### Cryptography Algorithms

--- a/java/src/main/java/com/cybersource/ws/client/Identity.java
+++ b/java/src/main/java/com/cybersource/ws/client/Identity.java
@@ -57,7 +57,7 @@ public class Identity {
         if(this.logger == null){
         	this.logger=logger;
         }
-        if(merchantConfig.isJdkCertEnabled()){
+        if(merchantConfig.isJdkCertEnabled() || merchantConfig.isCacertEnabled()){
             setupJdkServerCerts();
         }
         else{

--- a/java/src/main/java/com/cybersource/ws/client/MerchantConfig.java
+++ b/java/src/main/java/com/cybersource/ws/client/MerchantConfig.java
@@ -329,6 +329,17 @@ public class MerchantConfig {
                 throw new ConfigException("Invalid value of numberOfRetries and/or retryInterval");
             }
         }
+		if(isCacertEnabled()){
+        String keyPath=this.getKeysDirectory();
+        String keysFilename=this.getKeyFilename();
+        if(!(keyPath == null)){
+        	keysDirectory=keyPath;
+        }
+        if(!(keysFilename == null)){
+        	keyFilename=keysFilename;
+        	
+        }
+      }
     }
     
     /**

--- a/java/src/main/java/com/cybersource/ws/client/MerchantConfig.java
+++ b/java/src/main/java/com/cybersource/ws/client/MerchantConfig.java
@@ -330,15 +330,12 @@ public class MerchantConfig {
             }
         }
 		if(isCacertEnabled()){
-        String keyPath=this.getKeysDirectory();
-        String keysFilename=this.getKeyFilename();
-        if(!(keyPath == null)){
-        	keysDirectory=keyPath;
-        }
-        if(!(keysFilename == null)){
-        	keyFilename=keysFilename;
-        	
-        }
+        	if(StringUtils.isBlank(keysDirectory)){
+        		keysDirectory = System.getProperty("java.home") + "/lib/security".replace('/', File.separatorChar);
+        	}
+        	if(StringUtils.isBlank(keyFilename)){
+        		keyFilename = "cacerts";
+        	}
       }
     }
     

--- a/java/src/main/java/com/cybersource/ws/client/SecurityUtil.java
+++ b/java/src/main/java/com/cybersource/ws/client/SecurityUtil.java
@@ -278,7 +278,7 @@ public class SecurityUtil {
         
         else{
             try{
-                FileInputStream is = new FileInputStream(path);
+            	FileInputStream is = new FileInputStream(merchantConfig.getKeyFile());
                 keystore = KeyStore.getInstance(KeyStore.getDefaultType());
                 keystore.load(is, pass.toCharArray());
             }

--- a/java/src/main/java/com/cybersource/ws/client/SecurityUtil.java
+++ b/java/src/main/java/com/cybersource/ws/client/SecurityUtil.java
@@ -101,7 +101,7 @@ public class SecurityUtil {
             }
 			else if(merchantConfig.isCacertEnabled()){
                 logger.log(Logger.LT_INFO," Loading the certificate from JRE security cacert file");
-                SecurityUtil.readJdkCert(merchantConfig,logger);
+                SecurityUtil.loadJavaKeystore(merchantConfig,logger);
             }
             else{
                 logger.log(Logger.LT_INFO,"Loading the certificate from p12 file ");
@@ -265,18 +265,11 @@ public class SecurityUtil {
     }
     
     
-    public static void readJdkCert(MerchantConfig merchantConfig, Logger logger) throws SignEncryptException, SignException{
+    public static void readJdkCert(MerchantConfig merchantConfig, Logger logger) throws SignEncryptException, SignException, ConfigException{
         KeyStore keystore=null;
         
         String pass=merchantConfig.getKeyPassword();
         
-        if (merchantConfig.isCacertEnabled()){
-            String path = System.getProperty("java.home") + "/lib/security/cacerts".replace('/', File.separatorChar);
-            loadJavaKeystore(path, merchantConfig,logger);
-            
-        }
-        
-        else{
             try{
             	FileInputStream is = new FileInputStream(merchantConfig.getKeyFile());
                 keystore = KeyStore.getInstance(KeyStore.getDefaultType());
@@ -326,13 +319,13 @@ public class SecurityUtil {
                 logger.log(Logger.LT_EXCEPTION, "Exception while obtaining private key from KeyStore with alias, '" + merchantConfig.getKeyAlias() + "'");
                 throw new SignException(e);
             }
-        }
+        
    	}
     
-    private static void loadJavaKeystore(String keystore_location, MerchantConfig merchantConfig,Logger logger) throws SignException, SignEncryptException{
+    private static void loadJavaKeystore(MerchantConfig merchantConfig,Logger logger) throws SignException, SignEncryptException, ConfigException{
         FileInputStream is = null;
         try {
-            File file = new File(keystore_location);
+            File file = new File(merchantConfig.getKeyFile().getCanonicalPath());
             is = new FileInputStream(file);
             KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
             String password = merchantConfig.getCacertPassword();

--- a/java/src/main/java/com/cybersource/ws/client/SecurityUtil.java
+++ b/java/src/main/java/com/cybersource/ws/client/SecurityUtil.java
@@ -99,6 +99,10 @@ public class SecurityUtil {
                 logger.log(Logger.LT_INFO," Loading the certificate from JDK Cert");
                 SecurityUtil.readJdkCert(merchantConfig,logger);
             }
+			else if(merchantConfig.isCacertEnabled()){
+                logger.log(Logger.LT_INFO," Loading the certificate from JRE security cacert file");
+                SecurityUtil.readJdkCert(merchantConfig,logger);
+            }
             else{
                 logger.log(Logger.LT_INFO,"Loading the certificate from p12 file ");
                 readAndStoreCertificateAndPrivateKey(merchantConfig, logger);
@@ -264,11 +268,10 @@ public class SecurityUtil {
     public static void readJdkCert(MerchantConfig merchantConfig, Logger logger) throws SignEncryptException, SignException{
         KeyStore keystore=null;
         
-        String path=merchantConfig.getKeysDirectory()+"/"+merchantConfig.getKeyFilename();
         String pass=merchantConfig.getKeyPassword();
         
         if (merchantConfig.isCacertEnabled()){
-            path = System.getProperty("java.home") + "/lib/security/cacerts".replace('/', File.separatorChar);
+            String path = System.getProperty("java.home") + "/lib/security/cacerts".replace('/', File.separatorChar);
             loadJavaKeystore(path, merchantConfig,logger);
             
         }

--- a/java/src/main/resources/cybs.properties
+++ b/java/src/main/resources/cybs.properties
@@ -38,7 +38,7 @@ retryInterval=5
 enableJdkCert=false
 
 # if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert. This property will be considered only if enableJDKcert is set to true.
+# And it will read from JDK cert.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/java/src/main/resources/cybs.properties
+++ b/java/src/main/resources/cybs.properties
@@ -32,13 +32,12 @@ retryInterval=5
 #customHttpClassEnabled=
 #customHttpClass=
 
-# If This property is set to true then the p12 certificate must be stored in JKS format
-# program will read it from there. If it is set to false then the certificate will be read from 
-# the location specified above from the key directory location
+# If enableJdkCert property is set to true then the p12 certificate must be stored in JKS format.
+# program will read it from keysDirectory path.
 enableJdkCert=false
 
-# if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert.
+# If enableCacert property is enabled then it means the certificates are kept under the keysDirectory path. 
+# By default, keysDirectory path set to Java Installation cacerts location
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/java/src/main/resources/cybs.properties
+++ b/java/src/main/resources/cybs.properties
@@ -36,8 +36,8 @@ retryInterval=5
 # program will read it from keysDirectory path.
 enableJdkCert=false
 
-# If enableCacert property is enabled then it means the certificates are kept under the keysDirectory path. 
-# By default, keysDirectory path set to Java Installation cacerts location
+# If 'enableCacert' property parameter is set to true, certificates will be read from the cacerts file specified at keysDirectory      location. 
+# If keysDirectory path is not set,certificate will be loaded from Java Installation cacerts file. The cacerts file should be of the same name as specified in keyFilename.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/java/src/test/resources/test_cybs.properties
+++ b/java/src/test/resources/test_cybs.properties
@@ -36,7 +36,7 @@ retryInterval=5
 enableJdkCert=false
 
 # if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert. This property will be considered only if enableJDKcert is set to true.
+# And it will read from JDK cert.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/java/src/test/resources/test_cybs.properties
+++ b/java/src/test/resources/test_cybs.properties
@@ -34,8 +34,8 @@ retryInterval=5
 # program will read it from keysDirectory path.
 enableJdkCert=false
 
-# If enableCacert property is enabled then it means the certificates are kept under the keysDirectory path. 
-# By default, keysDirectory path set to Java Installation cacerts location
+# If 'enableCacert' property parameter is set to true, certificates will be read from the cacerts file specified at keysDirectory location. 
+# If keysDirectory path is not set,certificate will be loaded from Java Installation cacerts file. The cacerts file should be of the same name as specified in keyFilename.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/java/src/test/resources/test_cybs.properties
+++ b/java/src/test/resources/test_cybs.properties
@@ -30,13 +30,12 @@ retryInterval=5
 #customHttpClassEnabled=
 #customHttpClass=
 
-# If This property is set to true then the p12 certificate must be stored in JKS format
-# program will read it from there. If it is set to false then the certificate will be read from 
-# the location specified above from the key directory location
+# If enableJdkCert property is set to true then the p12 certificate must be stored in JKS format.
+# program will read it from keysDirectory path.
 enableJdkCert=false
 
-# if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert.
+# If enableCacert property is enabled then it means the certificates are kept under the keysDirectory path. 
+# By default, keysDirectory path set to Java Installation cacerts location
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/samples/nvp/cybs.properties
+++ b/samples/nvp/cybs.properties
@@ -39,7 +39,7 @@ retryInterval=5
 enableJdkCert=false
 
 # if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert. This property will be considered only if enableJDKcert is set to true.
+# And it will read from JDK cert.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/samples/nvp/cybs.properties
+++ b/samples/nvp/cybs.properties
@@ -37,8 +37,8 @@ retryInterval=5
 # program will read it from keysDirectory path.
 enableJdkCert=false
 
-# If enableCacert property is enabled then it means the certificates are kept under the keysDirectory path. 
-# By default, keysDirectory path set to Java Installation cacerts location
+# If 'enableCacert' property parameter is set to true, certificates will be read from the cacerts file specified at keysDirectory location. 
+# If keysDirectory path is not set,certificate will be loaded from Java Installation cacerts file. The cacerts file should be of the same name as specified in keyFilename.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/samples/nvp/cybs.properties
+++ b/samples/nvp/cybs.properties
@@ -33,13 +33,12 @@ retryInterval=5
 #customHttpClassEnabled=
 #customHttpClass=
 
-# If This property is set to true then the p12 certificate must be stored in JKS format
-# program will read it from there. If it is set to false then the certificate will be read from 
-# the location specified above from the key directory location
+# If enableJdkCert property is set to true then the p12 certificate must be stored in JKS format.
+# program will read it from keysDirectory path.
 enableJdkCert=false
 
-# if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert.
+# If enableCacert property is enabled then it means the certificates are kept under the keysDirectory path. 
+# By default, keysDirectory path set to Java Installation cacerts location
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/samples/xml/cybs.properties
+++ b/samples/xml/cybs.properties
@@ -39,7 +39,7 @@ retryInterval=5
 enableJdkCert=false
 
 # if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert. This property will be considered only if enableJDKcert is set to true.
+# And it will read from JDK cert.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/samples/xml/cybs.properties
+++ b/samples/xml/cybs.properties
@@ -37,8 +37,8 @@ retryInterval=5
 # program will read it from keysDirectory path.
 enableJdkCert=false
 
-# If enableCacert property is enabled then it means the certificates are kept under the keysDirectory path. 
-# By default, keysDirectory path set to Java Installation cacerts location
+# If 'enableCacert' property parameter is set to true, certificates will be read from the cacerts file specified at keysDirectory location. 
+# If keysDirectory path is not set,certificate will be loaded from Java Installation cacerts file. The cacerts file should be of the same name as specified in keyFilename.
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/samples/xml/cybs.properties
+++ b/samples/xml/cybs.properties
@@ -33,13 +33,12 @@ retryInterval=5
 #customHttpClassEnabled=
 #customHttpClass=
 
-# If This property is set to true then the p12 certificate must be stored in JKS format
-# program will read it from there. If it is set to false then the certificate will be read from 
-# the location specified above from the key directory location
+# If enableJdkCert property is set to true then the p12 certificate must be stored in JKS format.
+# program will read it from keysDirectory path.
 enableJdkCert=false
 
-# if Cacert property is enabled then it means the certificates are kept under the cacert folder of JDK
-# And it will read from JDK cert.
+# If enableCacert property is enabled then it means the certificates are kept under the keysDirectory path. 
+# By default, keysDirectory path set to Java Installation cacerts location
 enableCacert=false
 # Enter the password for cacert file. Default password for JDK cacert is changeit
 cacertPassword=

--- a/zip/README
+++ b/zip/README
@@ -63,7 +63,7 @@ Refer to our Developer's Guide for details <http://apps.cybersource.com/library/
 
     h. "serverURL" config parameter will take precedence over sendToProduction and sendToAkamai config parameters. By default the "serverURL" configuration is commented out. 
  
-    i. if `enablejdkcert` parameter is set to true, certificates will be read from the JKS file specified at keysDirectory location. The JKS file should be of the same name as specified in keyFilename.
+    i. if `enableJdkcert` parameter is set to true, certificates will be read from the JKS file specified at keysDirectory location. The JKS file should be of the same name as specified in keyFilename.
 	To convert p12 to JKS refer to the JKS creation section.
 
     j. - If 'enableCacert' property parameter is set to true, certificates will be read from the cacerts file specified at keysDirectory location.If keysDirectory path is not set,certificate will be loaded from Java Installation cacerts file. The cacerts file should be of the same name as specified in keyFilename.

--- a/zip/README
+++ b/zip/README
@@ -66,7 +66,7 @@ Refer to our Developer's Guide for details <http://apps.cybersource.com/library/
     i. if `enablejdkcert` parameter is set to true, certificates will be read from the JKS file specified at keysDirectory location. The JKS file should be of the same name as specified in keyFilename.
 	To convert p12 to JKS refer to the JKS creation section.
 
-    j. `cacerts` property is considered only if `enablejdkcert` is set to true. If `cacerts` is set to true, certificates will be read from the cacerts folder under the JDK. 
+    j. - If 'enableCacert' property parameter is set to true, certificates will be read from the cacerts file specified at keysDirectory location.If keysDirectory path is not set,certificate will be loaded from Java Installation cacerts file. The cacerts file should be of the same name as specified in keyFilename.
 
     k. "allowRetry" config parameter will only work for HttpClient. Set allowRetry config parameter to "true" to enable retry mechanism and set merchant specific values for the retry. 
        Set integer values for config parameter numberOfRetries & retryInterval. Retry Interval is time delay for next retry in seconds. number of retry parameter should be set between


### PR DESCRIPTION
Now user can load jks or cacerts file at runtime similar like  p12 file. System is capable to read the new JSK or cacerts file at runtime . Also to removed the dependency of enableJdkCert=true while loading the cacerts file . So system can read cacerts file even enableJdkCert=false . Details mentioned in README.MD file