### PR TITLE
fixing failed to sign issue, which was due to wrong pwd used while si…

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -210,12 +210,12 @@
             <groupId>org.apache.ws.security</groupId>
             <artifactId>wss4j</artifactId>
             <version>1.6.19</version>
-	<exclusions>
+	        <exclusions>
                 <exclusion>
                     <groupId>org.opensaml</groupId>
                     <artifactId>opensaml</artifactId>
                 </exclusion>
-         </exclusions>
+            </exclusions>
         </dependency>     
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/java/src/main/java/com/cybersource/ws/client/Identity.java
+++ b/java/src/main/java/com/cybersource/ws/client/Identity.java
@@ -40,7 +40,9 @@ public class Identity {
 	private long lastModifiedDate;
     
     private static final String SERVER_ALIAS = "CyberSource_SJC_US";
-    
+
+    private char[] pswd;
+
     private Logger logger = null;
     
     /**
@@ -122,11 +124,8 @@ public class Identity {
     */
     
 	public boolean isValid(File keyFile) {
-		
 		boolean changeKeyFileStatus=(this.lastModifiedDate == keyFile.lastModified());
-
 		if (!changeKeyFileStatus) {
-
 			logger.log(Logger.LT_INFO, "Key file changed");
 			logger.log(Logger.LT_INFO, "Timestamp of current key file:"+keyFile.lastModified());	
 		}
@@ -142,6 +141,7 @@ public class Identity {
                     throw new SignException("Exception while obtaining private key from KeyStore with alias, '" + merchantConfig.getKeyAlias() + "'");
                 }
                 name = merchantConfig.getMerchantID();
+                pswd = merchantConfig.getKeyPassword().toCharArray();
                 serialNumber = subjectDNrray[1];
                 keyAlias = "serialNumber=" + serialNumber + ",CN=" + name;
             } else {
@@ -197,8 +197,11 @@ public class Identity {
         
         return serialNumber;
     }
-    
-    
+
+    public char[] getPswd() {
+        return pswd;
+    }
+
     public void setSerialNumber(String serialNumber) {
         this.serialNumber = serialNumber;
     }

--- a/java/src/main/java/com/cybersource/ws/client/MessageHandlerKeyStore.java
+++ b/java/src/main/java/com/cybersource/ws/client/MessageHandlerKeyStore.java
@@ -26,7 +26,7 @@ public class MessageHandlerKeyStore extends Merlin {
         try {
             if (privateKey != null) {
                 X509Certificate[] certChain = {certificate};
-                getKeyStore().setKeyEntry(id.getKeyAlias(), privateKey, id.getName().toCharArray(), certChain);
+                getKeyStore().setKeyEntry(id.getKeyAlias(), privateKey, id.getPswd(), certChain);
             } else {
                 getKeyStore().setCertificateEntry(id.getKeyAlias(), certificate);
             }

--- a/java/src/test/java/com/cybersource/ws/client/IdentityTest.java
+++ b/java/src/test/java/com/cybersource/ws/client/IdentityTest.java
@@ -30,7 +30,7 @@ public class IdentityTest{
     }
 
     @Test
-    public void testSetUpMerchant() throws InstantiationException, IllegalAccessException, SignException, ConfigException{
+    public void testSetUpMerchant() throws SignException, ConfigException{
     	File p12file = Mockito.mock(File.class);
     	MerchantConfig mc = Mockito.mock(MerchantConfig.class);
     	
@@ -43,9 +43,11 @@ public class IdentityTest{
     	Mockito.when(principal.getName()).thenReturn(keyAlias);
     	
     	Mockito.when(mc.getKeyFile()).thenReturn(p12file);
+		Mockito.when(mc.getKeyPassword()).thenReturn("testPwd");
     	Identity identity = new Identity(mc,x509Cert,pkey,logger);
     	assertEquals(identity.getName(), mc.getMerchantID());
     	assertEquals(identity.getSerialNumber(), "400000009910179089277");
+		assertEquals(String.valueOf(identity.getPswd()), "testPwd");
     	assertNotNull(identity.getPrivateKey());
     }
     

--- a/java/src/test/java/com/cybersource/ws/client/SecurityUtilIT.java
+++ b/java/src/test/java/com/cybersource/ws/client/SecurityUtilIT.java
@@ -163,13 +163,20 @@ public class SecurityUtilIT {
         
     	Mockito.when(identity.getPrivateKey()).thenReturn(newPkay);
     	Mockito.when(identity.getX509Cert()).thenReturn(x509Cert);
-    	Mockito.when(identity.getName()).thenReturn("MahenCertTest");
     	Mockito.when(identity.getKeyAlias()).thenReturn("MahenCertTest");
+        Mockito.when(identity.getPswd()).thenReturn("testPwd".toCharArray());
     	
     	MessageHandlerKeyStore mhKeyStore= new MessageHandlerKeyStore();    	
+
     	MessageHandlerKeyStore spyMhKeyStore = Mockito.spy(mhKeyStore);
     	Mockito.when(spyMhKeyStore.getKeyStore()).thenReturn(myKeystore);
     	spyMhKeyStore.addIdentityToKeyStore(identity,logger);
+
+    	Mockito.verify(identity,times(1)).getKeyAlias();
+        Mockito.verify(identity,times(1)).getPrivateKey();
+        Mockito.verify(identity,times(1)).getPswd();
+        Mockito.verify(identity,times(1)).getX509Cert();
+
     }
     
 	@Test  

--- a/pom.xml
+++ b/pom.xml
@@ -4,16 +4,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-
-    <name>cybersource-sdk-java-master</name>
-
-    <modules>
-        <module>zip</module>
-        <module>java</module>
-    </modules>
-
-    <packaging>pom</packaging>
-
     <parent>
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
@@ -23,6 +13,11 @@
     <groupId>com.cybersource</groupId>
     <artifactId>cybersource-sdk-master</artifactId>
     <version>6.2.7-SNAPSHOT</version>
+    <name>cybersource-sdk-java-master</name>
+    <packaging>pom</packaging>
 
-
+    <modules>
+        <module>zip</module>
+        <module>java</module>
+    </modules>
 </project>

--- a/zip/pom.xml
+++ b/zip/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cybersource-sdk-zip</artifactId>
-    <name>${artifactId}</name>
+    <name>${project.artifactId}</name>
     <packaging>pom</packaging>
 
     <build>


### PR DESCRIPTION
Earlier we were using merchantId as password while loading p12 file content to localkeystore which is used to sign the document.

Fixed by using keyfile password.